### PR TITLE
Changing variables names 'var' to 'std'

### DIFF
--- a/03_debuggin_and_visualization/vae_mnist_working.py
+++ b/03_debuggin_and_visualization/vae_mnist_working.py
@@ -47,15 +47,15 @@ class Encoder(nn.Module):
         mean     = self.FC_mean(h_)
         log_var  = self.FC_var(h_)                     
                                                       
-        var      = torch.exp(0.5*log_var)             
-        z        = self.reparameterization(mean, var)
+        std      = torch.exp(0.5*log_var)             
+        z        = self.reparameterization(mean, std)
         
         return z, mean, log_var
        
-    def reparameterization(self, mean, var,):
-        epsilon = torch.rand_like(var)
+    def reparameterization(self, mean, std,):
+        epsilon = torch.rand_like(std)
         
-        z = mean + var*epsilon
+        z = mean + std*epsilon
         
         return z
     


### PR DESCRIPTION
For the `reparameterization` function, the `var` parameter actually acts as the standard deviation (`sqrt(var)`), due to the `0.5` in `torch.exp(0.5*log_var)`. I think the variable names should reflect that
