### PR TITLE
Update M8_dvc.md

### DIFF
--- a/s2_organisation_and_version_control/M8_dvc.md
+++ b/s2_organisation_and_version_control/M8_dvc.md
@@ -58,8 +58,10 @@ contains excellent tutorials.
 2. Next, install dvc and the google drive extenstion
    ```bash
    pip install dvc
-   pip install dvc[gdrive]
+   pip install "dvc[gdrive]"
    ```
+   > If you installed DVC via pip and plan to use cloud services as remote storage, you might need to install these optional dependencies: [s3], [azure], [gdrive], [gs], [oss], [ssh]. Alternatively, use [all] to include them all. The command should look like this: pip install "dvc[s3]".
+
 
 3. In your mnist repository run the following command from the terminal
    ```bash


### PR DESCRIPTION
I found a bug in this chapter, about installing the dvc[gdrive].
The right command is: pip install "dvc[gdrive]"
we need to type in a double quotes.