### PR TITLE
deleted unused cost function, changed prints statement to fstring

### DIFF
--- a/s3_reproducibility/exercise_files/vae_mnist.py
+++ b/s3_reproducibility/exercise_files/vae_mnist.py
@@ -42,8 +42,6 @@ model = Model(Encoder=encoder, Decoder=decoder).to(DEVICE)
 
 from torch.optim import Adam
 
-BCE_loss = nn.BCELoss()
-
 def loss_function(x, x_hat, mean, log_var):
     reproduction_loss = nn.functional.binary_cross_entropy(x_hat, x, reduction='sum')
     KLD      = - 0.5 * torch.sum(1+ log_var - mean.pow(2) - log_var.exp())
@@ -70,7 +68,7 @@ for epoch in range(epochs):
         
         loss.backward()
         optimizer.step()
-    print("\tEpoch", epoch + 1, "complete!", "\tAverage Loss: ", overall_loss / (batch_idx*batch_size))    
+    print(f"Epoch {epoch+1} complete!,  Average Loss: {overall_loss / (batch_idx*batch_size)}")    
 print("Finish!!")
 
 # save weights


### PR DESCRIPTION
I got `TypeError: not all arguments converted during string formatting` when using `logging` in the `vae_minst.py` file. I also removed a cost function (`BCE_loss`) which is defined later (`reproduction_loss`)