### PR TITLE
Fix confusion matrix display in CML script

### DIFF
--- a/s5_continuous_integration/cml.md
+++ b/s5_continuous_integration/cml.md
@@ -71,7 +71,7 @@ after the run is done.
     with open("classification_report.txt", 'w') as outfile:
         outfile.write(report)
     confmat = confusion_matrix(target, preds)
-    disp = ConfusionMatrixDisplay(cm = confmat, )
+    disp = ConfusionMatrixDisplay(confusion_matrix = confmat)
     plt.savefig('confusion_matrix.png')
     ```
 


### PR DESCRIPTION
The `ConfusionMatrixDisplay` class is now initialized with the correct parameter name `confusion_matrix` instead of `cm`. 

the orginal version gives TypeError in the runtime
```
TypeError: ConfusionMatrixDisplay.__init__() got an unexpected keyword argument 'cm'
```