### PR TITLE
Fix gcloud command in using_the_cloud.md

### DIFF
--- a/s6_the_cloud/using_the_cloud.md
+++ b/s6_the_cloud/using_the_cloud.md
@@ -59,7 +59,7 @@ We are now going to start actually using the cloud.
 5. You can start a terminal directly by typing:
 
     ```bash
-    gcloud beta compute ssh --zone <zone> <name> --project <project-id>
+    gcloud compute ssh --zone <zone> <name> --project <project-id>
     ```
 
     You can always see the exact command that you need to run to `ssh` to an VM by selecting the

--- a/s6_the_cloud/using_the_cloud.md
+++ b/s6_the_cloud/using_the_cloud.md
@@ -162,7 +162,7 @@ We are going to follow the instructions from this [page](https://dvc.org/doc/use
 3. Next we need the Google storage extension for `dvc`
 
     ```bash
-    pip install dvc[gs]
+    pip install "dvc[gs]"
     ```
 
 4. Now in your MNIST repository where you have already configured dvc, we are going to change the storage


### PR DESCRIPTION
This pull request fixes the `gcloud` command in the `using_the_cloud.md` file. The command was updated to remove the `beta` flag, as it is no longer needed.