### PR TITLE
Fix missing environment activation patch for Windows

### DIFF
--- a/s1_development_environment/package_manager.md
+++ b/s1_development_environment/package_manager.md
@@ -59,6 +59,7 @@ the same environment, in this case the global environment. Instead, if we did so
     .\env\Scripts\activate  # activate that virtual environment
     pip install torch==2.0  # install new torch version into the virtual environment belonging to project B
     cd ../project_A  # move back to project A
+    .\env\Scripts\activate  # activate the virtual environment belonging to project A
     python main.py  # succeed in executing main script from project A
     ```
 


### PR DESCRIPTION
Commit 687e7da fixes missing activation of environment. It did not apply correction for Windows instructions.