### PR TITLE
Update cli.md

### DIFF
--- a/s2_organisation_and_version_control/cli.md
+++ b/s2_organisation_and_version_control/cli.md
@@ -321,7 +321,7 @@ easier.
     returns the current Python interpreter but it works for all operating systems. Check that it works by running:
 
     ```bash
-    invoke hello
+    invoke python
     ```
 
 4. Lets try to create a task that simplifies the process of `git add`, `git commit`, `git push`. Create a task such


### PR DESCRIPTION
Changes typo from "hello" to "python" in invoke command.

Think there is a type where you call "invoke hello" instead of "invoke python". The error may be a result of an earlier command that called "Hello world" instead of printing the current python version (current)