### PR TITLE
Updated select with lint.select

### DIFF
--- a/s2_organisation_and_version_control/good_coding_practice.md
+++ b/s2_organisation_and_version_control/good_coding_practice.md
@@ -131,7 +131,7 @@ the `pyproject.toml` file.
 
     ```toml
     [tool.ruff]
-    select = ["I"]
+    lint.select = ["I"]
     ```
 
     and try re-running `ruff check` and `ruff format`. Hopefully this should reorganize your imports to follow common


### PR DESCRIPTION
Updated the `ruff` section in `pyproject.toml` to replace the deprecated `select` key with `lint.select`.