### PR TITLE
Adapted path in text to match path in code solution

### DIFF
--- a/s1_development_environment/deep_learning_software.md
+++ b/s1_development_environment/deep_learning_software.md
@@ -172,7 +172,7 @@ pip install gdown
 gdown --folder 'https://drive.google.com/drive/folders/1ddWeCcsfmelqxF8sOGBihY9IU98S9JRP?usp=sharing'
 ```
 
-The data should be placed in a folder subfolder called `data/corruptedmnist` in the root of the project. Your overall
+The data should be placed in a folder subfolder called `data/corruptmnist` in the root of the project. Your overall
 task is the following:
 
 > **Implement an MNIST neural network that achieves at least 85% accuracy on the test set.**


### PR DESCRIPTION
Since the code solution has implemented 'DATA_PATH = "data/corruptmnist"', it didnt match the previous suggestion in the text to create a directory 'data/corruptedmnist', so I fixed that issue by changing the text to match the code.