### PR TITLE
Fix error with members names

### DIFF
--- a/s3_reproducibility/exercise_files/vae_mnist.py
+++ b/s3_reproducibility/exercise_files/vae_mnist.py
@@ -34,7 +34,7 @@ test_loader = DataLoader(dataset=test_dataset, batch_size=batch_size, shuffle=Fa
 encoder = Encoder(input_dim=x_dim, hidden_dim=hidden_dim, latent_dim=20)
 decoder = Decoder(latent_dim=20, hidden_dim=hidden_dim, output_dim=x_dim)
 
-model = Model(Encoder=encoder, Decoder=decoder).to(DEVICE)
+model = Model(encoder=encoder, decoder=decoder).to(DEVICE)
 
 
 def loss_function(x, x_hat, mean, log_var):


### PR DESCRIPTION
The code gives error because the model constructor is defined as: def __init__(self, encoder, decoder) -> None:
  ...
however here the members were called starting with capital letters. As a result the code doesn't work.