### PR TITLE
Fix 'Tip' infobox of M4 by adding delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ## ℹ️ Course information
 
 * Course responsible
-    * Postdoc [Nicki Skafte Detlefsen](https://skaftenicki.github.io/),  <nsde@dtu.dk>
-    * Professor [Søren Hauberg](http://www2.compute.dtu.dk/~sohau/),  <sohau@dtu.dk>
+    * Postdoc [Nicki Skafte Detlefsen](https://skaftenicki.github.io/), <nsde@dtu.dk>
+    * Professor [Søren Hauberg](http://www2.compute.dtu.dk/~sohau/), <sohau@dtu.dk>
 * 5 ECTS (European Credit Transfer System), corresponding to 140 hours of work
 * 3 week period in January
 * Master level course


### PR DESCRIPTION
Previously, the infobox did not render as it missed a delimiter. This commit fixes this issue and has been verified by serving the mkdocs. 