### PR TITLE
Docs: fix formatting in Exercise 12 from M10

### DIFF
--- a/s3_reproducibility/docker.md
+++ b/s3_reproducibility/docker.md
@@ -260,7 +260,7 @@ beneficial for you to download.
     3. Finally, we are going to name our training script as the *entrypoint* for our Docker image. The *entrypoint* is
         the application that we want to run when the image is executed:
 
-        === "Using pip
+        === "Using pip"
 
             ```docker
             ENTRYPOINT ["python", "-u", "src/<project-name>/train.py"]


### PR DESCRIPTION
This PR fixes a formatting error found on Exercise 12 from M10 which was breaking the "Using pip" / "Using uv" tabs for the code display:

- Adds missing `"` so the formatting is not broken

Screenshot of the issue:

<img width="739" height="398" alt="image" src="https://github.com/user-attachments/assets/aff77e77-6f3b-4811-abef-21474d8f60c3" />