### PR TITLE
Adds missing quote to fix formatting in S5 docs

### DIFF
--- a/s5_continuous_integration/unittesting.md
+++ b/s5_continuous_integration/unittesting.md
@@ -288,7 +288,7 @@ The following exercises should be applied to your MNIST repository
 
     3. To get a simple coverage report simply type
 
-        === "Using pip
+        === "Using pip"
 
             ```bash
             coverage report -m


### PR DESCRIPTION
There's a small issue on S5 docs [here](https://skaftenicki.github.io/dtu_mlops/s5_continuous_integration/unittesting/), caused by a missing quote which I add in this PR. 

<img width="737" height="293" alt="Screenshot 2026-01-12 at 2 36 00 PM" src="https://github.com/user-attachments/assets/df78a33c-cf45-4146-ad0c-061f0ff6f487" />
