### PR TITLE
Fix typo: wonking -> working in package manager docs

### DIFF
--- a/s1_development_environment/package_manager.md
+++ b/s1_development_environment/package_manager.md
@@ -415,7 +415,7 @@ to make it work.
             uv python pin 3.13
             ```
 
-    8. Assume you have a friend wonking on the same project as you and they are using `pip` together with good old
+    8. Assume you have a friend working on the same project as you and they are using `pip` together with good old
         `requirements.txt` files. How do you create a `requirements.txt` file from your `uv` project?
 
         ??? success "Solution"


### PR DESCRIPTION
Fix minor typo (“wonking” → “working”) in package manager documentation