### PR TITLE
Dependabot yaml formatting

### DIFF
--- a/s5_continuous_integration/github_actions.md
+++ b/s5_continuous_integration/github_actions.md
@@ -468,8 +468,8 @@ have in your code.
             version: 2
             updates:
             - package-ecosystem: "pip"
-                directory: "/"
-                schedule:
+              directory: "/"
+              schedule:
                 interval: "weekly"
             ```
 
@@ -479,8 +479,8 @@ have in your code.
             version: 2
             updates:
             - package-ecosystem: "uv"
-                directory: "/"
-                schedule:
+              directory: "/"
+              schedule:
                 interval: "weekly"
             ```
 
@@ -535,7 +535,7 @@ have in your code.
     ...
     ```
 
-    The `@v4` specifies that we are using version 4 of the `actions/checkout` action. This means that if a new version
+    The `@v5` specifies that we are using version 5 of the `actions/checkout` action. This means that if a new version
     of the action is released, we will not automatically get the new version. Dependabot can help us with this. Try
     adding to the `dependabot.yaml` file that Dependabot should also check for updates in the GitHub Actions ecosystem.
 
@@ -549,6 +549,7 @@ have in your code.
           schedule:
             interval: "weekly"
         - package-ecosystem: "github-actions"
+          directory: "/"
           schedule:
             interval: "weekly"
         ```
@@ -569,7 +570,7 @@ have in your code.
         * Workflow: A `yaml` file that defines the instructions to be executed on specific events. Needs to be placed in
             the `.github/workflows` folder.
         * Runner: Workflows need to run somewhere. The environment that the workflow is being executed on is called the
-            runner. Most commonly the runner is hosted by GitHub but can also hosted by yourself.
+            runner. Most commonly the runner is hosted by GitHub but can also be hosted by yourself.
         * Job: A series of steps that are executed on the same runner. A workflow must include at least one job but
             often contains many.
         * Action: An action is the smallest unit in a workflow. Jobs often consist of multiple actions that are


### PR DESCRIPTION
Had a few problems with the `dependabot.yaml` file:
- Think `directory` and `schedule` should be on the same level as `package-ecosystem`. 
- The `directory` should always be specified for a package-ecosystem.