### PR TITLE
Fix issue with grapping the wrong (overall) Readme.md in report.py

### DIFF
--- a/reports/report.py
+++ b/reports/report.py
@@ -83,7 +83,8 @@ app = typer.Typer()
 @app.command()
 def html() -> None:
     """Convert README.md to html page."""
-    with Path("README.md").open() as file:
+    path = "reports/README.md" if Path("reports/README.md").exists() else "README.md"
+    with Path(path).open() as file:
         text = file.read()
     text = text[43:]  # remove header
 

--- a/reports/report.py
+++ b/reports/report.py
@@ -96,7 +96,8 @@ def html() -> None:
 @app.command()
 def check() -> None:
     """Check if report satisfies the requirements."""
-    with Path("README.md").open() as file:
+    path = "reports/README.md" if Path("reports/README.md").exists() else "README.md"
+    with Path(path).open() as file:
         text = file.read()
 
     # answers in general can be found between "Answer:" and "###" or "##"
@@ -172,3 +173,4 @@ def check() -> None:
 
 if __name__ == "__main__":
     app()
+

--- a/reports/report.py
+++ b/reports/report.py
@@ -174,4 +174,3 @@ def check() -> None:
 
 if __name__ == "__main__":
     app()
-


### PR DESCRIPTION
report.py might grab the wrong readme.md file (the project root readme.md) when running both check and html.
This can generate either errors, wrong constrain warnings or a weird looking pdf, which can be confusing.

The code now looks for reports/readme.md first, then falls back to readme.md.
This allows you to run the code inside the folder, using uv invoke and generally run in the root folder, which (I think) is pretty common when using uv.