### PR TITLE
Fix PyTorch model call

### DIFF
--- a/s1_development_environment/exercise_files/5_Inference_and_Validation.ipynb
+++ b/s1_development_environment/exercise_files/5_Inference_and_Validation.ipynb
@@ -340,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -376,7 +376,7 @@
     "\n",
     "# Calculate the class probabilities (softmax) for img\n",
     "with torch.no_grad():\n",
-    "    output = model.forward(img)\n",
+    "    output = model(img)\n",
     "\n",
     "ps = torch.exp(output)\n",
     "\n",


### PR DESCRIPTION
Changed the model invocation from model.forward(...) to model(...) to follow the PyTorch-recommended nn.Module calling pattern, which preserves the standard module call behavior such as registered hooks. The execution_count change is only notebook metadata and is not functionally relevant.